### PR TITLE
Add dynamic political topics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>TItle!</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter&display=swap" rel="stylesheet">
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Inter', Helvetica, Arial, sans-serif;
+            background-color: #444;
+            color: #fff;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            text-align: center;
+        }
+        h1 {
+            font-size: 3em;
+            margin: 0.2em 0;
+        }
+        p.description {
+            font-size: 1.2em;
+            margin: 0.2em 0;
+        }
+        ul.topics {
+            list-style: none;
+            padding: 0;
+        }
+    </style>
+</head>
+<body>
+    <h1>TItle!</h1>
+    <p class="description">Most talked about political topics in the last 25 minutes:</p>
+    <ul id="topics" class="topics"></ul>
+
+    <script>
+        async function fetchTopics() {
+            const API_KEY = 'YOUR_NEWS_API_KEY'; // Replace with a valid NewsAPI key
+            const url = `https://newsapi.org/v2/top-headlines?category=politics&pageSize=5&apiKey=${API_KEY}`;
+            try {
+                const resp = await fetch(url);
+                if (!resp.ok) throw new Error('Network response was not ok');
+                const data = await resp.json();
+                const topicsEl = document.getElementById('topics');
+                data.articles.forEach(article => {
+                    const li = document.createElement('li');
+                    li.textContent = article.title;
+                    topicsEl.appendChild(li);
+                });
+            } catch (err) {
+                const topicsEl = document.getElementById('topics');
+                topicsEl.innerHTML = '<li>Unable to load topics.</li>';
+            }
+        }
+        fetchTopics();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show heading `TItle!`
- add Google font and script to load top political headlines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854507da1a083298a1bd0c78bd1af8c