### PR TITLE
Add web-based Wikipedia pageviews dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Wikipedia Pageviews</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="app-shell">
+    <header class="app-header">
+      <h1>Wikipedia Pageviews</h1>
+      <p id="subtitle">Explore how often an article was viewed in the last 60 days on en-wiki.</p>
+    </header>
+
+    <main class="app-main">
+      <section class="search-card">
+        <div class="search-bar">
+          <label class="sr-only" for="article-input">Article title</label>
+          <input id="article-input" type="text" placeholder="Search for an article" autocomplete="off" />
+          <button id="fetch-button" type="button">Fetch views</button>
+        </div>
+
+        <div class="suggestions">
+          <div class="suggestions-heading" id="suggestions-heading">Trending this week</div>
+          <div class="suggestions-track" id="suggestions-track"></div>
+        </div>
+
+        <div class="filters">
+          <div class="filter">
+            <label for="range-input">Range</label>
+            <output id="range-output">60 days</output>
+            <input id="range-input" type="range" min="7" max="365" value="60" />
+          </div>
+          <div class="filter">
+            <label for="language-select">Language</label>
+            <select id="language-select">
+              <option value="en.wikipedia.org">en-wiki</option>
+              <option value="he.wikipedia.org">he-wiki</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="status" id="status">Ready.</div>
+
+        <div class="table-wrapper">
+          <table id="results-table">
+            <thead>
+              <tr>
+                <th data-column="date">Date</th>
+                <th data-column="views">Views</th>
+                <th data-column="edits">Edits</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+
+        <div class="chart" id="chart-container">
+          <canvas id="chart" width="800" height="220" aria-label="Pageviews chart"></canvas>
+        </div>
+
+        <div class="totals" id="totals">Totals — views: –, edits: –</div>
+        <p class="hint">Tip: double-click a row to open a same-day Google search. Columns are sortable.</p>
+      </section>
+    </main>
+  </div>
+
+  <div class="tooltip" id="tooltip" role="tooltip" hidden></div>
+
+  <script src="main.js" type="module"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,841 @@
+const API_URL =
+  "https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/" +
+  "{project}/{access}/{agent}/{article}/{granularity}/{start}/{end}";
+const EDITS_URL =
+  "https://wikimedia.org/api/rest_v1/metrics/edits/per-page/" +
+  "{project}/{article}/{editor_type}/{granularity}/{start}/{end}";
+const TOP_ARTICLES_URL =
+  "https://wikimedia.org/api/rest_v1/metrics/pageviews/top/" +
+  "{project}/all-access/{year}/{month}/{day}";
+const SUMMARY_URL = "https://{project}/api/rest_v1/page/summary/{title}?redirect=true";
+const USER_AGENT = "WikipediaViewsWeb/1.0 (https://github.com/)";
+
+const LANGUAGE_LABELS = new Map([
+  ["en.wikipedia.org", "en-wiki"],
+  ["he.wikipedia.org", "he-wiki"],
+]);
+
+const state = {
+  currentData: [],
+  sort: {
+    date: false,
+    views: true,
+    edits: true,
+  },
+  pointLookup: new Map(),
+  chartPoints: [],
+  chartMeta: {},
+  articleSummaries: new Map(),
+  summaryRequests: new Set(),
+  tooltipVisibleFor: null,
+  trendingCache: new Map(),
+  trendingAbort: null,
+};
+
+const selectors = {
+  articleInput: document.getElementById("article-input"),
+  fetchButton: document.getElementById("fetch-button"),
+  rangeInput: document.getElementById("range-input"),
+  rangeOutput: document.getElementById("range-output"),
+  languageSelect: document.getElementById("language-select"),
+  status: document.getElementById("status"),
+  totals: document.getElementById("totals"),
+  subtitle: document.getElementById("subtitle"),
+  tableBody: document.querySelector("#results-table tbody"),
+  tableHeaders: Array.from(document.querySelectorAll("#results-table th")),
+  chart: document.getElementById("chart"),
+  suggestionsHeading: document.getElementById("suggestions-heading"),
+  suggestionsTrack: document.getElementById("suggestions-track"),
+  tooltip: document.getElementById("tooltip"),
+};
+
+const dpr = window.devicePixelRatio || 1;
+
+init();
+
+function init() {
+  selectors.articleInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      triggerFetch();
+    }
+  });
+
+  selectors.fetchButton.addEventListener("click", triggerFetch);
+  selectors.rangeInput.addEventListener("input", handleRangeChange);
+  selectors.languageSelect.addEventListener("change", handleFilterChange);
+  selectors.tableHeaders.forEach((header) =>
+    header.addEventListener("click", () => handleSort(header.dataset.column))
+  );
+  selectors.tableBody.addEventListener("dblclick", handleRowDoubleClick);
+
+  selectors.chart.addEventListener("mousemove", handleChartHover);
+  selectors.chart.addEventListener("mouseleave", clearChartHover);
+  window.addEventListener("resize", () => drawChart());
+
+  selectors.suggestionsTrack.addEventListener("pointerleave", hideTooltip);
+
+  updateRangeOutput(getSelectedDays());
+  updateSubtitle();
+  requestTrendingArticles();
+}
+
+function handleRangeChange() {
+  const days = getSelectedDays();
+  updateRangeOutput(days);
+  updateSubtitle();
+  maybeNotifyFilters();
+}
+
+function handleFilterChange() {
+  updateSubtitle();
+  requestTrendingArticles(true);
+  maybeNotifyFilters();
+}
+
+function maybeNotifyFilters() {
+  if (state.currentData.length === 0) {
+    setStatus("Ready.");
+    return;
+  }
+
+  const language = LANGUAGE_LABELS.get(selectors.languageSelect.value) ?? "en-wiki";
+  const days = getSelectedDays();
+  setStatus(`Filters updated — press Fetch to refresh (${language}, ${days} days).`);
+}
+
+function getSelectedDays() {
+  return Math.min(365, Math.max(7, Number.parseInt(selectors.rangeInput.value, 10) || 60));
+}
+
+function updateRangeOutput(days) {
+  selectors.rangeOutput.textContent = `${days} day${days === 1 ? "" : "s"}`;
+}
+
+function updateSubtitle() {
+  const days = getSelectedDays();
+  const language = LANGUAGE_LABELS.get(selectors.languageSelect.value) ?? "en-wiki";
+  selectors.subtitle.textContent = `Explore how often an article was viewed in the last ${days} days on ${language}.`;
+}
+
+function decodeUnicode(input) {
+  if (typeof input !== "string") return input;
+  let value = input;
+  let previous;
+  while (previous !== value) {
+    previous = value;
+    value = value.replace(/\\\\u/gi, "\\u").replace(/\\\\U/g, "\\U");
+  }
+  try {
+    return value.replace(/\\u[0-9a-fA-F]{4}/g, (m) => String.fromCharCode(parseInt(m.slice(2), 16)));
+  } catch (error) {
+    return input;
+  }
+}
+
+async function triggerFetch() {
+  const raw = selectors.articleInput.value.trim();
+  const article = decodeUnicode(raw);
+  if (!article) {
+    alert("Please enter a Wikipedia article title.");
+    return;
+  }
+
+  selectors.articleInput.value = article;
+  const project = selectors.languageSelect.value;
+  const days = getSelectedDays();
+  const language = LANGUAGE_LABELS.get(project) ?? project;
+  setStatus(`Fetching data… (${language}, last ${days} days)`);
+  setTotals("Totals — views: –, edits: –");
+  clearTable();
+  clearChart();
+  disableFetch(true);
+
+  try {
+    const { data, warning } = await fetchPageMetrics(article, project, days);
+    if (!data || data.length === 0) {
+      setStatus("No data returned for that article.");
+      state.currentData = [];
+      drawChart();
+      return;
+    }
+
+    state.currentData = data;
+    state.sort = { date: false, views: true, edits: true };
+    const sorted = [...data].sort((a, b) => b.views - a.views);
+    populateTable(sorted);
+    drawChart();
+    let status = `Metrics for '${article}' - ${language}, last ${days} days`;
+    if (warning) {
+      status += ` — ${warning}`;
+    }
+    setStatus(status);
+  } catch (error) {
+    console.error(error);
+    const message = error?.message ?? "Unknown error";
+    setStatus("Could not retrieve data.");
+    alert(message);
+    state.currentData = [];
+    drawChart();
+  } finally {
+    disableFetch(false);
+  }
+}
+
+function disableFetch(disabled) {
+  selectors.fetchButton.disabled = disabled;
+}
+
+function setStatus(message) {
+  selectors.status.textContent = message;
+}
+
+function setTotals(message) {
+  selectors.totals.textContent = message;
+}
+
+function clearTable() {
+  selectors.tableBody.innerHTML = "";
+  state.pointLookup.clear();
+}
+
+function populateTable(data) {
+  clearTable();
+  let totalViews = 0;
+  let totalEdits = 0;
+  const fragment = document.createDocumentFragment();
+
+  for (const entry of data) {
+    const row = document.createElement("tr");
+    row.dataset.date = entry.date.toISOString();
+
+    const dateCell = document.createElement("td");
+    dateCell.textContent = formatDate(entry.date);
+    const viewsCell = document.createElement("td");
+    viewsCell.textContent = formatNumber(entry.views);
+    const editsCell = document.createElement("td");
+    editsCell.textContent = formatNumber(entry.edits);
+
+    row.append(dateCell, viewsCell, editsCell);
+    fragment.append(row);
+
+    totalViews += entry.views;
+    totalEdits += entry.edits;
+    state.pointLookup.set(entry.date.toISOString(), row);
+  }
+
+  selectors.tableBody.append(fragment);
+  setTotals(`Totals — views: ${formatNumber(totalViews)}, edits: ${formatNumber(totalEdits)}`);
+}
+
+function handleSort(column) {
+  if (!column || state.currentData.length === 0) return;
+
+  const descending = !state.sort[column];
+  state.sort[column] = descending;
+
+  let sorted;
+  if (column === "date") {
+    sorted = [...state.currentData].sort((a, b) =>
+      descending ? b.date - a.date : a.date - b.date
+    );
+  } else if (column === "views") {
+    sorted = [...state.currentData].sort((a, b) =>
+      descending ? b.views - a.views : a.views - b.views
+    );
+  } else {
+    sorted = [...state.currentData].sort((a, b) =>
+      descending ? b.edits - a.edits : a.edits - b.edits
+    );
+  }
+
+  populateTable(sorted);
+  drawChart(sorted);
+}
+
+function handleRowDoubleClick(event) {
+  const row = event.target.closest("tr");
+  if (!row) return;
+  const iso = row.dataset.date;
+  const date = iso ? new Date(iso) : null;
+  const article = selectors.articleInput.value.trim();
+  if (!date || !article) return;
+
+  const formatted = `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
+  const params = new URLSearchParams({
+    q: `"${article}"`,
+    tbs: `cdr:1,cd_min:${formatted},cd_max:${formatted}`,
+  });
+  const url = `https://www.google.com/search?${params.toString()}`;
+  window.open(url, "_blank", "noopener");
+}
+
+function clearChart() {
+  const canvas = selectors.chart;
+  const ctx = canvas.getContext("2d");
+  resizeCanvas(canvas, ctx);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  state.chartPoints = [];
+  state.chartMeta = {};
+}
+
+function drawChart(data = state.currentData) {
+  const canvas = selectors.chart;
+  const ctx = canvas.getContext("2d");
+  resizeCanvas(canvas, ctx);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  state.chartPoints = [];
+  state.chartMeta = {};
+
+  if (!data || data.length === 0) {
+    ctx.fillStyle = "#8892b0";
+    ctx.font = `${14 * dpr}px sans-serif`;
+    ctx.textAlign = "center";
+    ctx.fillText("No data yet. Fetch to see the trend.", canvas.width / 2, canvas.height / 2);
+    return;
+  }
+
+  const sorted = [...data].sort((a, b) => a.date - b.date);
+  const padding = 30 * dpr;
+  const width = canvas.width;
+  const height = canvas.height;
+  const plotWidth = width - padding * 2;
+  const plotHeight = height - padding * 2;
+
+  const maxViews = Math.max(...sorted.map((d) => d.views));
+  const minViews = Math.min(...sorted.map((d) => d.views));
+  const range = Math.max(1, maxViews - minViews);
+  const count = sorted.length;
+
+  const points = [];
+  if (count === 1) {
+    points.push({
+      x: padding + plotWidth / 2,
+      y: height - padding - plotHeight / 2,
+    });
+  } else {
+    const step = plotWidth / (count - 1);
+    sorted.forEach((entry, index) => {
+      const normalized = range === 0 ? 0 : (entry.views - minViews) / range;
+      const x = padding + index * step;
+      const y = height - padding - normalized * plotHeight;
+      points.push({ x, y });
+    });
+  }
+
+  ctx.save();
+  ctx.strokeStyle = "#cdd5eb";
+  ctx.lineWidth = 1 * dpr;
+  ctx.beginPath();
+  ctx.moveTo(padding, height - padding);
+  ctx.lineTo(width - padding, height - padding);
+  ctx.moveTo(padding, padding);
+  ctx.lineTo(padding, height - padding);
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = "rgba(79, 70, 229, 0.15)";
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, height - padding);
+  points.forEach((point, index) => {
+    if (index === 0) {
+      ctx.lineTo(point.x, point.y);
+    } else {
+      ctx.lineTo(point.x, point.y);
+    }
+  });
+  ctx.lineTo(points[points.length - 1].x, height - padding);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+
+  ctx.save();
+  ctx.strokeStyle = "#4f46e5";
+  ctx.lineWidth = 2 * dpr;
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i += 1) {
+    ctx.lineTo(points[i].x, points[i].y);
+  }
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = "#4f46e5";
+  points.forEach((point) => {
+    ctx.beginPath();
+    ctx.arc(point.x, point.y, 3 * dpr, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = "#4f46e5";
+  ctx.font = `${12 * dpr}px sans-serif`;
+  ctx.textAlign = "left";
+  ctx.fillText(`Peak: ${formatNumber(maxViews)}`, padding + 8 * dpr, padding + 12 * dpr);
+  ctx.textAlign = "right";
+  ctx.fillStyle = "#6b7280";
+  ctx.fillText(`Min: ${formatNumber(minViews)}`, width - padding, padding + 12 * dpr);
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = "#6b7280";
+  ctx.font = `${11 * dpr}px sans-serif`;
+  ctx.textAlign = "center";
+  const firstLabel = formatShortDate(sorted[0].date);
+  const lastLabel = formatShortDate(sorted[sorted.length - 1].date);
+  ctx.fillText(firstLabel, points[0].x, height - padding + 16 * dpr);
+  ctx.fillText(lastLabel, points[points.length - 1].x, height - padding + 16 * dpr);
+  ctx.restore();
+
+  state.chartPoints = points.map((point, index) => ({
+    x: point.x,
+    y: point.y,
+    date: sorted[index].date,
+    views: sorted[index].views,
+    edits: sorted[index].edits,
+  }));
+  state.chartMeta = { padding, width, height };
+}
+
+function resizeCanvas(canvas, ctx) {
+  const rect = canvas.getBoundingClientRect();
+  const width = Math.max(1, Math.floor(rect.width * dpr));
+  const height = Math.max(1, Math.floor(rect.height * dpr));
+  if (canvas.width !== width || canvas.height !== height) {
+    canvas.width = width;
+    canvas.height = height;
+  }
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+}
+
+function handleChartHover(event) {
+  if (!state.chartPoints.length) return;
+
+  const rect = selectors.chart.getBoundingClientRect();
+  const x = (event.clientX - rect.left) * dpr;
+  const padding = state.chartMeta.padding ?? 0;
+  const width = state.chartMeta.width ?? selectors.chart.width;
+  if (x < padding || x > width - padding) {
+    clearChartHover();
+    return;
+  }
+
+  const nearest = [...state.chartPoints].reduce((best, point) => {
+    if (!best) return point;
+    const current = Math.abs(point.x - x);
+    const bestDistance = Math.abs(best.x - x);
+    return current < bestDistance ? point : best;
+  }, null);
+
+  if (!nearest) return;
+  drawChart();
+  highlightPoint(nearest);
+  selectRowForDate(nearest.date);
+}
+
+function highlightPoint(point) {
+  const canvas = selectors.chart;
+  const ctx = canvas.getContext("2d");
+  const padding = state.chartMeta.padding ?? 0;
+
+  ctx.save();
+  ctx.strokeStyle = "#4f46e5";
+  ctx.lineWidth = 1 * dpr;
+  ctx.setLineDash([4 * dpr, 2 * dpr]);
+  ctx.beginPath();
+  ctx.moveTo(point.x, padding);
+  ctx.lineTo(point.x, (state.chartMeta.height ?? canvas.height) - padding);
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = "#ffffff";
+  ctx.strokeStyle = "#4f46e5";
+  ctx.lineWidth = 2 * dpr;
+  ctx.beginPath();
+  ctx.arc(point.x, point.y, 6 * dpr, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.stroke();
+  ctx.restore();
+
+  ctx.save();
+  ctx.fillStyle = "#4f46e5";
+  ctx.font = `${11 * dpr}px sans-serif`;
+  ctx.textAlign = "center";
+  const text = `${formatDate(point.date)} — ${formatNumber(point.views)} views, ${formatNumber(point.edits)} edits`;
+  const textX = Math.min(
+    Math.max(point.x, padding + 50 * dpr),
+    (state.chartMeta.width ?? canvas.width) - padding - 50 * dpr
+  );
+  const textY = point.y - 12 * dpr < padding ? point.y + 20 * dpr : point.y - 12 * dpr;
+  ctx.fillText(text, textX, textY);
+  ctx.restore();
+}
+
+function clearChartHover() {
+  drawChart();
+  if (selectors.tableBody) {
+    const selected = selectors.tableBody.querySelector("tr.selected");
+    if (selected) selected.classList.remove("selected");
+  }
+}
+
+function selectRowForDate(date) {
+  const iso = date.toISOString();
+  const row = state.pointLookup.get(iso);
+  if (!row) return;
+
+  selectors.tableBody.querySelectorAll("tr").forEach((tr) => tr.classList.remove("selected"));
+  row.classList.add("selected");
+  row.scrollIntoView({ block: "nearest" });
+}
+
+function formatNumber(value) {
+  return Number(value).toLocaleString();
+}
+
+function formatDate(date) {
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function formatShortDate(date) {
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+async function fetchPageMetrics(article, project, days) {
+  const [startDate, endDate] = computeDateRange(days);
+  const articleSlug = encodeURIComponent(article.replace(/ /g, "_"));
+  const url = API_URL.replace("{project}", project)
+    .replace("{access}", "all-access")
+    .replace("{agent}", "user")
+    .replace("{article}", articleSlug)
+    .replace("{granularity}", "daily")
+    .replace("{start}", startDate)
+    .replace("{end}", endDate);
+
+  const viewsResponse = await safeFetch(url);
+  if (!viewsResponse.ok) {
+    if (viewsResponse.status === 404) {
+      throw new Error("Article not found or no pageviews available. Check the title and try again.");
+    }
+    throw new Error(`HTTP error ${viewsResponse.status}: ${viewsResponse.statusText}`);
+  }
+  const viewsData = await viewsResponse.json();
+  const items = viewsData.items ?? [];
+  if (!items.length) {
+    return { data: [], warning: null };
+  }
+
+  const views = items
+    .map((entry) => {
+      const timestamp = entry?.timestamp;
+      const count = entry?.views;
+      if (!timestamp || typeof count !== "number") return null;
+      const date = parseTimestamp(timestamp);
+      return date ? { date, views: count } : null;
+    })
+    .filter(Boolean);
+
+  if (!views.length) {
+    return { data: [], warning: null };
+  }
+
+  const { map: edits, warning } = await fetchPageEdits(articleSlug, project, startDate, endDate);
+  const data = views.map((entry) => ({
+    date: entry.date,
+    views: entry.views,
+    edits: edits.get(entry.date.toISOString()) ?? 0,
+  }));
+  return { data, warning };
+}
+
+async function fetchPageEdits(articleSlug, project, startDate, endDate) {
+  const url = EDITS_URL.replace("{project}", project)
+    .replace("{article}", articleSlug)
+    .replace("{editor_type}", "all-editor-types")
+    .replace("{granularity}", "daily")
+    .replace("{start}", startDate)
+    .replace("{end}", endDate);
+
+  try {
+    const response = await safeFetch(url);
+    if (!response.ok) {
+      if (response.status === 404) {
+        return { map: new Map(), warning: null };
+      }
+      throw new Error(`HTTP error while fetching edits: ${response.status}`);
+    }
+
+    const data = await response.json();
+    const items = data.items ?? [];
+    const map = new Map();
+    for (const item of items) {
+      const results = item?.results ?? [];
+      for (const entry of results) {
+        const timestamp = entry?.timestamp;
+        const count = entry?.edits;
+        if (!timestamp || typeof count !== "number") continue;
+        const date = parseIsoDate(timestamp);
+        if (!date) continue;
+        map.set(date.toISOString(), Math.trunc(count));
+      }
+    }
+    return { map, warning: null };
+  } catch (error) {
+    console.warn(error);
+    return {
+      map: new Map(),
+      warning: error instanceof Error ? error.message : "Network error while fetching edits",
+    };
+  }
+}
+
+function parseTimestamp(timestamp) {
+  try {
+    const dt = new Date(
+      Date.UTC(
+        Number(timestamp.slice(0, 4)),
+        Number(timestamp.slice(4, 6)) - 1,
+        Number(timestamp.slice(6, 8))
+      )
+    );
+    return dt;
+  } catch (error) {
+    return null;
+  }
+}
+
+function parseIsoDate(value) {
+  try {
+    return new Date(value);
+  } catch (error) {
+    return null;
+  }
+}
+
+function computeDateRange(days) {
+  const now = new Date();
+  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 1));
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - (days - 1));
+  const startStr = formatDateStamp(start);
+  const endStr = formatDateStamp(end);
+  return [startStr, endStr];
+}
+
+function formatDateStamp(date) {
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getUTCDate()}`.padStart(2, "0");
+  return `${year}${month}${day}`;
+}
+
+async function requestTrendingArticles(force = false) {
+  const project = selectors.languageSelect.value;
+  const cached = state.trendingCache.get(project);
+  if (!force && cached) {
+    applyTrendingArticles(project, cached);
+    return;
+  }
+
+  if (state.trendingAbort) {
+    state.trendingAbort.abort();
+  }
+
+  const controller = new AbortController();
+  state.trendingAbort = controller;
+  selectors.suggestionsHeading.textContent = "Trending this week (loading…)";
+  selectors.suggestionsTrack.innerHTML = "";
+
+  try {
+    const articles = await fetchTopArticles(project, { signal: controller.signal });
+    if (controller.signal.aborted) return;
+    if (!articles.length) {
+      selectors.suggestionsHeading.textContent = "Trending this week (unavailable)";
+      return;
+    }
+    state.trendingCache.set(project, articles);
+    applyTrendingArticles(project, articles);
+  } catch (error) {
+    if (controller.signal.aborted) return;
+    console.warn(error);
+    selectors.suggestionsHeading.textContent = "Trending this week (unavailable)";
+  }
+}
+
+function applyTrendingArticles(project, articles) {
+  if (selectors.languageSelect.value !== project) return;
+  selectors.suggestionsHeading.textContent = "Trending this week";
+  selectors.suggestionsTrack.innerHTML = "";
+  for (const title of articles) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "suggestion-button";
+    button.textContent = formatSuggestionTitle(title);
+    button.addEventListener("click", () => {
+      selectors.articleInput.value = formatSuggestionTitle(title);
+      triggerFetch();
+    });
+    button.addEventListener("pointerenter", (event) => showTooltip(event, project, title));
+    button.addEventListener("pointermove", positionTooltip);
+    button.addEventListener("pointerleave", hideTooltip);
+    selectors.suggestionsTrack.append(button);
+  }
+}
+
+function formatSuggestionTitle(title) {
+  try {
+    return decodeURIComponent(title).replace(/_/g, " ");
+  } catch (error) {
+    return title.replace(/_/g, " ");
+  }
+}
+
+async function showTooltip(event, project, article) {
+  const tooltip = selectors.tooltip;
+  const key = `${project}|${article}`;
+  tooltip.hidden = false;
+  tooltip.dataset.visible = "true";
+
+  const cached = state.articleSummaries.get(key);
+  if (cached) {
+    tooltip.textContent = cached;
+  } else if (!state.summaryRequests.has(key)) {
+    tooltip.textContent = "Loading summary…";
+    fetchArticleSummary(project, article)
+      .then((summary) => {
+        if (summary) {
+          state.articleSummaries.set(key, summary);
+          if (state.tooltipVisibleFor === key) {
+            tooltip.textContent = summary;
+          }
+        }
+      })
+      .catch(() => {
+        const fallback = "Summary unavailable.";
+        state.articleSummaries.set(key, fallback);
+        if (state.tooltipVisibleFor === key) {
+          tooltip.textContent = fallback;
+        }
+      });
+  } else {
+    tooltip.textContent = "Loading summary…";
+  }
+
+  state.tooltipVisibleFor = key;
+  positionTooltip(event);
+}
+
+function positionTooltip(event) {
+  const tooltip = selectors.tooltip;
+  const rect = event.currentTarget.getBoundingClientRect();
+  const x = rect.left + rect.width / 2;
+  const y = rect.bottom + 12;
+  tooltip.style.left = `${x}px`;
+  tooltip.style.top = `${y}px`;
+}
+
+function hideTooltip() {
+  state.tooltipVisibleFor = null;
+  const tooltip = selectors.tooltip;
+  tooltip.hidden = true;
+  tooltip.dataset.visible = "false";
+}
+
+async function fetchArticleSummary(project, article) {
+  const key = `${project}|${article}`;
+  if (state.articleSummaries.has(key)) {
+    return state.articleSummaries.get(key);
+  }
+  if (state.summaryRequests.has(key)) {
+    return null;
+  }
+
+  state.summaryRequests.add(key);
+  const slug = encodeURIComponent(article.replace(/ /g, "_"));
+  const url = SUMMARY_URL.replace("{project}", project).replace("{title}", slug);
+
+  try {
+    const response = await safeFetch(url);
+    if (!response.ok) {
+      return "Summary unavailable.";
+    }
+    const data = await response.json();
+    const extract = data.extract || data.title;
+    if (!extract) return "Summary unavailable.";
+    const sentence = extract.replace(/\s+/g, " ").trim();
+    const firstSentence = sentence.match(/[^.!?]+[.!?]/);
+    return firstSentence ? firstSentence[0] : `${sentence}.`;
+  } catch (error) {
+    console.warn(error);
+    return "Summary unavailable.";
+  } finally {
+    state.summaryRequests.delete(key);
+  }
+}
+
+async function fetchTopArticles(project, { days = 7, limit = 20, signal } = {}) {
+  const aggregated = new Map();
+  const today = new Date();
+  const tasks = [];
+
+  for (let offset = 1; offset <= days; offset += 1) {
+    const day = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate() - offset));
+    const year = day.getUTCFullYear();
+    const month = `${day.getUTCMonth() + 1}`.padStart(2, "0");
+    const dayStr = `${day.getUTCDate()}`.padStart(2, "0");
+    const projectSlug = project.replace(/\.org$/, "");
+    const url = TOP_ARTICLES_URL.replace("{project}", projectSlug)
+      .replace("{year}", String(year))
+      .replace("{month}", month)
+      .replace("{day}", dayStr);
+
+    tasks.push(
+      safeFetch(url, { signal })
+        .then((response) => (response.ok ? response.json() : null))
+        .then((data) => {
+          const items = data?.items ?? [];
+          for (const item of items) {
+            for (const entry of item?.articles ?? []) {
+              const title = entry?.article;
+              const views = entry?.views;
+              if (!title || typeof views !== "number") continue;
+              if (title === "Main_Page" || title.startsWith("Special:")) continue;
+              const key = title;
+              aggregated.set(key, (aggregated.get(key) ?? 0) + views);
+            }
+          }
+        })
+        .catch(() => null)
+    );
+  }
+
+  await Promise.all(tasks);
+  const sorted = [...aggregated.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([title]) => title);
+  return sorted;
+}
+
+async function safeFetch(url, options = {}) {
+  const merged = {
+    ...options,
+    headers: {
+      "Api-User-Agent": USER_AGENT,
+      ...(options.headers || {}),
+    },
+  };
+  return fetch(url, merged);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,305 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background-color: #f5f7fb;
+  color: #0f172a;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: #f5f7fb;
+  min-height: 100vh;
+}
+
+.app-shell {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 48px 24px 64px;
+}
+
+.app-header h1 {
+  margin: 0 0 8px;
+  font-size: clamp(28px, 4vw, 42px);
+  font-weight: 700;
+}
+
+.app-header p {
+  margin: 0;
+  color: #64748b;
+  font-size: 1.05rem;
+}
+
+.search-card {
+  margin-top: 32px;
+  background: #ffffff;
+  border-radius: 28px;
+  padding: 32px clamp(24px, 4vw, 48px);
+  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.search-bar {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.search-bar input {
+  flex: 1;
+  border-radius: 16px;
+  border: 1px solid #cbd5f5;
+  padding: 14px 18px;
+  font-size: 1rem;
+  transition: box-shadow 0.2s ease, border 0.2s ease;
+}
+
+.search-bar input:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.25);
+}
+
+.search-bar button {
+  border: none;
+  background: linear-gradient(135deg, #6366f1, #4f46e5);
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 14px 24px;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search-bar button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px -10px rgba(79, 70, 229, 0.6);
+}
+
+.search-bar button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.filters {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.filter label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #64748b;
+  margin-bottom: 12px;
+}
+
+.filter output {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 10px;
+  color: #312e81;
+}
+
+.filter input[type="range"] {
+  width: 100%;
+}
+
+.filter select {
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid #cbd5f5;
+  padding: 12px 14px;
+  font-size: 1rem;
+  background: #f8f9ff;
+}
+
+.suggestions {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.suggestions-heading {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.suggestions-track {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scroll-snap-type: x mandatory;
+}
+
+.suggestions-track::-webkit-scrollbar {
+  height: 6px;
+}
+
+.suggestions-track::-webkit-scrollbar-thumb {
+  background: rgba(99, 102, 241, 0.4);
+  border-radius: 999px;
+}
+
+.suggestion-button {
+  scroll-snap-align: start;
+  border: none;
+  background: #eef2ff;
+  color: #1f2937;
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+  white-space: nowrap;
+}
+
+.suggestion-button:hover {
+  background: #d9ddff;
+  transform: translateY(-1px);
+}
+
+.status {
+  font-size: 1rem;
+  color: #475569;
+}
+
+.table-wrapper {
+  border-radius: 20px;
+  border: 1px solid #e2e8f0;
+  overflow: hidden;
+}
+
+#results-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.98rem;
+}
+
+#results-table thead {
+  background: #f1f5f9;
+}
+
+#results-table th,
+#results-table td {
+  padding: 14px 18px;
+  text-align: left;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+#results-table th {
+  font-weight: 700;
+  color: #1e293b;
+  cursor: pointer;
+  user-select: none;
+}
+
+#results-table td:nth-child(2),
+#results-table td:nth-child(3) {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+#results-table tbody tr:hover {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+#results-table tbody tr.selected {
+  background: rgba(79, 70, 229, 0.16);
+}
+
+.chart {
+  background: #eef2ff;
+  border-radius: 20px;
+  padding: 18px 20px;
+}
+
+#chart {
+  width: 100%;
+  height: 220px;
+}
+
+.totals {
+  text-align: right;
+  font-weight: 600;
+  color: #1e1b4b;
+  font-size: 1.05rem;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+.tooltip {
+  position: fixed;
+  max-width: 320px;
+  background: #ffffff;
+  color: #1f2937;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  padding: 12px 14px;
+  box-shadow: 0 18px 40px -25px rgba(15, 23, 42, 0.45);
+  font-size: 0.85rem;
+  pointer-events: none;
+  z-index: 50;
+}
+
+.tooltip[data-visible="true"] {
+  visibility: visible;
+  opacity: 1;
+}
+
+.tooltip[hidden] {
+  visibility: hidden;
+  opacity: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .search-card {
+    border-radius: 20px;
+    padding: 28px 20px;
+  }
+
+  .search-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-bar button {
+    width: 100%;
+  }
+
+  .filters {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add an HTML shell, styles, and JavaScript to deliver the Wikipedia pageviews GUI in the browser
- implement API calls for pageviews, edits, article summaries, and trending titles with responsive UI behavior
- render interactive charting, sortable metrics table, and tooltip-enhanced trending suggestions

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68deeaef198c832988abe8267b456616